### PR TITLE
fix(app.py): fix no internal_screen scaling being applied in `PkApp.render()`

### DIFF
--- a/puffkit/app.py
+++ b/puffkit/app.py
@@ -156,7 +156,10 @@ class PkApp(PkObject):
         self.internal_screen.fill(PkBasicPalette.WHITE)
         self.active_scene.render(self.internal_screen)
 
-        self.display.blit(self.internal_screen.internal_surface, (0, 0))
+        scaled = pg.transform.scale(
+            self.internal_screen.internal_surface, self.display_size.tuple
+        )
+        self.display.blit(scaled, (0, 0))
         pg.display.flip()
 
     def run(self, *, run_once: bool = False) -> None:


### PR DESCRIPTION
## PR type (check all applicable)

- [ ] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This pull request includes a change to the `render` method in the `puffkit/app.py` file to improve the display scaling functionality.

Display scaling improvement:

* [`puffkit/app.py`](diffhunk://#diff-7ab55bb5b176c09b766a4e622326d73d9eeaa08fea6eafcce89a5f1ad83e30f9L159-R162): Modified the `render` method to scale the `internal_screen` to the `display_size` before blitting it to the display.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

_replace this line with instructions (screenshots) on how to test, use your changes_
