### PR TITLE
feat: add text input widget

### DIFF
--- a/puffkit/container.py
+++ b/puffkit/container.py
@@ -47,10 +47,7 @@ class PkContainer(PkObject):
 
         self.widgets: dict[str, PkWidget] = {}
 
-        if isinstance(rect, PkRect):
-            self.rect: PkRect = rect
-        else:
-            self.rect: PkRect = PkRect.from_tuple(rect)
+        self.rect: PkRect = PkRect.from_value(rect)
 
         # check if the container is out of bounds
         if self.rect.x < 0:

--- a/puffkit/event/event_manager.py
+++ b/puffkit/event/event_manager.py
@@ -86,6 +86,8 @@ class PkEventManager:
                     * self.app.internal_screen_size.height
                     / self.app.display_size.height,
                 )
+            elif e.type in (pg.KEYDOWN, pg.KEYUP):  # pragma: no cover
+                e.key = pg.key.name(e.key)
 
         self.events = [PkEvent.from_pygame(e) for e in pygame_events]
         self.app.scene_manager.input(

--- a/puffkit/geometry/rect.py
+++ b/puffkit/geometry/rect.py
@@ -46,7 +46,26 @@ class PkRect(PkObject):
         self.h: float = h
 
     @classmethod
+    def from_value(cls, rect: RectValue | PkRect) -> PkRect:
+        """Create a rectangle from a tuple of values.
+
+        Args:
+            rect (RectValue): A tuple of values representing the rectangle.
+
+        Returns:
+            PkRect: The created rectangle.
+        """
+        if isinstance(rect, PkRect):
+            return rect
+        return cls(*rect)
+
+    @classmethod
     def from_tuple(cls, rect: RectValue) -> PkRect:
+        """# DEPRECATED
+
+        This method is deprecated. Use `from_value` instead.
+        """
+        raise DeprecationWarning("from_tuple is deprecated. Use from_value instead.")
         return cls(*rect)
 
     @property

--- a/puffkit/geometry/rect.py
+++ b/puffkit/geometry/rect.py
@@ -58,7 +58,7 @@ class PkRect(PkObject):
         return cls(*rect)
 
     @classmethod
-    def from_tuple(cls, rect: RectValue) -> PkRect:
+    def from_tuple(cls, rect: RectValue) -> PkRect:  # pragma: no cover
         """# DEPRECATED
 
         This method is deprecated. Use `from_value` instead.

--- a/puffkit/geometry/rect.py
+++ b/puffkit/geometry/rect.py
@@ -6,8 +6,6 @@ import logging as lg
 
 import pygame
 
-from puffkit.geometry.coordinate import PkCoordinate
-from puffkit.geometry.size import PkSize
 from puffkit.object import PkObject
 
 type RectValue = tuple[int | float, int | float, int | float, int | float]

--- a/puffkit/surface.py
+++ b/puffkit/surface.py
@@ -685,8 +685,7 @@ class PkSurface(PkObject):
             bg_color = PkColor.from_value(bg_color) if bg_color is not None else None
 
         # rect conversion
-        if not isinstance(rect, PkRect):
-            rect = PkRect.from_tuple(rect)
+        rect = PkRect.from_value(rect)
 
         text_surface: PkSurface = PkSurface(rect.size, transparent=True)
 

--- a/puffkit/widget/__init__.py
+++ b/puffkit/widget/__init__.py
@@ -1,5 +1,5 @@
 from .widget import PkWidget
 
 from .label_widget import PkLabelWidget
-
 from .button_widget import PkButtonWidget
+from .text_input_widget import PkTextInputWidget

--- a/puffkit/widget/button_widget.py
+++ b/puffkit/widget/button_widget.py
@@ -75,7 +75,7 @@ class PkButtonWidget(PkWidget):
             border_radius (int, optional): The border radius of the button.
                 Defaults to 0.
         """
-        super().__init__(id_, container, rect)
+        super().__init__(id_, container, rect, focusable=True)
 
         if not isinstance(background_color, PkColor):
             background_color = PkColor.from_value(background_color)

--- a/puffkit/widget/label_widget.py
+++ b/puffkit/widget/label_widget.py
@@ -144,8 +144,9 @@ class PkLabelWidget(PkWidget):
 
     def on_render(self) -> None:
         """Render the label widget."""
-        if not self.needs_redraw:
-            return
+        # redraw all labels every frame
+        # if not self.needs_redraw:
+        #     return
 
         self.surface.fill(self.background_color)
 

--- a/puffkit/widget/text_input_widget.py
+++ b/puffkit/widget/text_input_widget.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pygame
+from puffkit import PkContainer
+from puffkit.widget import PkWidget, PkLabelWidget
+from puffkit.color import PkBasicPalette
+from puffkit.geometry import PkRect, RectValue
+from puffkit.color import PkColor, ColorValue
+
+if TYPE_CHECKING:  # pragma: no cover
+    from puffkit.event import PkEvent
+
+
+class PkTextInputWidget(PkWidget):
+    """A customizable text input widget for one-line user input.
+
+    PkTextInputWidget provides a text box with configurable appearance and behavior,
+    including support for text alignment, input validation, and state-based styling
+    (e.g., disabled, focused).
+    """
+
+    def __init__(
+        self,
+        id_: str,
+        container: PkContainer,
+        rect: PkRect | RectValue,
+        text: str = "",
+        *,
+        on_change: Any | None = None,
+        on_focus: Any | None = None,
+        on_unfocus: Any | None = None,
+        disabled: bool = False,
+        font_id: str = "default",
+        background_color: PkColor | ColorValue = PkBasicPalette.GREY,
+        background_color_disabled: PkColor | ColorValue = PkBasicPalette.DARK_GREY,
+        background_color_focused: PkColor | ColorValue = PkBasicPalette.BLUE,
+        text_color: PkColor | ColorValue = PkBasicPalette.WHITE,
+        text_align: str = "left",
+        border_radius: int = 0,
+        padding: int = 2,
+        max_length: int = 0,
+        placeholder: str = "",
+        placeholder_color: PkColor | ColorValue = PkBasicPalette.LIGHT_GREY,
+        placeholder_color_disabled: PkColor | ColorValue = PkBasicPalette.GREY,
+        placeholder_color_focused: PkColor | ColorValue = PkBasicPalette.LIGHT_GREY,
+    ) -> None:
+        """Initialize the text input widget.
+
+        Args:
+            id_ (str): The unique identifier for the widget.
+            container (PkContainer): The parent container for the widget.
+            rect (PkRect | RectValue): The rectangle defining the widget's
+                position and size.
+            text (str, optional): The initial text in the text box.
+                Defaults to "".
+            on_change (Any | None, optional): Callback function for text change
+                events. Defaults to None.
+            on_focus (Any | None, optional): Callback function for focus events.
+                Defaults to None.
+            on_unfocus (Any | None, optional): Callback function for unfocus
+                events. Defaults to None.
+            disabled (bool, optional): Whether the widget is disabled.
+                Defaults to False.
+            font_id (str, optional): The font ID for the text.
+                Defaults to "default".
+            background_color (PkColor | ColorValue, optional): Background color
+                of the text box. Defaults to PkBasicPalette.GREY.
+            background_color_disabled (PkColor | ColorValue, optional):
+                Background color when disabled. Defaults to PkBasicPalette.DARK_GREY.
+            background_color_focused (PkColor | ColorValue, optional):
+                Background color when focused. Defaults to PkBasicPalette.BLUE.
+            text_color (PkColor | ColorValue, optional): Text color.
+                Defaults to PkBasicPalette.WHITE.
+            text_align (str, optional): Text alignment ("left", "center", "right").
+                Defaults to "left".
+            padding (int, optional): Padding inside the text box. Defaults to 2.
+            border_radius (int, optional): Border radius of the text box.
+                Defaults to 0.
+            max_length (int, optional): Maximum length of input text.
+                Defaults to 0 (no limit).
+            placeholder (str, optional): Placeholder text. Defaults to "".
+            placeholder_color (PkColor | ColorValue, optional): Placeholder color.
+                Defaults to PkBasicPalette.LIGHT_GREY.
+            placeholder_color_disabled (PkColor | ColorValue, optional):
+                Placeholder color when disabled. Defaults to PkBasicPalette.GREY.
+            placeholder_color_focused (PkColor | ColorValue, optional):
+                Placeholder color when focused. Defaults to PkBasicPalette.LIGHT_GREY.
+
+        Raises:
+            ValueError: If the provided rectangle is invalid or if the maximum length is negative.
+
+        """
+        super().__init__(id_, container, rect, focusable=True)
+        self.text: str = text
+
+        self.action_on_change: Any | None = on_change
+        self.action_on_focus: Any | None = on_focus
+        self.action_on_unfocus: Any | None = on_unfocus
+
+        self.disabled: bool = disabled
+        self.font_id: str = font_id
+
+        self.background_color: PkColor | ColorValue = PkColor.from_value(
+            background_color
+        )
+        self.background_color_disabled: PkColor | ColorValue = PkColor.from_value(
+            background_color_disabled
+        )
+        self.background_color_focused: PkColor | ColorValue = PkColor.from_value(
+            background_color_focused
+        )
+        self.text_color: PkColor | ColorValue = PkColor.from_value(text_color)
+
+        self.text_align: str = text_align
+        self.border_radius: int = border_radius
+        self.max_length: int = max_length
+
+        self.placeholder: str = placeholder
+        self.placeholder_color: PkColor | ColorValue = PkColor.from_value(
+            placeholder_color
+        )
+        self.placeholder_color_disabled: PkColor | ColorValue = PkColor.from_value(
+            placeholder_color_disabled
+        )
+        self.placeholder_color_focused: PkColor | ColorValue = PkColor.from_value(
+            placeholder_color_focused
+        )
+
+        self.cursor: int = len(self.text)
+        self.cursor_chars: list[str] = ["|", "¦"]
+        self.cursor_blink_interval: float = 0.6
+        self.cursor_blink_timer: float = 0.0
+
+        # check if the padding isn't too large
+        if padding * 2 >= self.rect.w or padding * 2 >= self.rect.h:
+            raise ValueError(
+                "Padding is too large for the input field. "
+                f"Input field width: {self.rect.w}, "
+                f"Input field height: {self.rect.h}, "
+                f"Padding: {padding}"
+            )
+
+        inner_container_rect: PkRect = PkRect(
+            padding,
+            padding,
+            self.rect.w - padding * 2,
+            self.rect.h - padding * 2,
+        )  # inner rectangle for the text box
+
+        inner_container_widget_rect: PkRect = PkRect(
+            0,
+            0,
+            self.rect.w - padding * 2,
+            self.rect.h - padding * 2,
+        )  # inner rectangle for the text box widget
+
+        # inner container for the text box
+        self._inner_container: PkContainer = PkContainer(
+            self.container.app,
+            self.surface,
+            f"{self.id}_inner_container",
+            inner_container_rect,
+        )
+
+        self._inner_container.add_widget(
+            PkLabelWidget(
+                f"{self.id}_text",
+                self._inner_container,
+                self.text,
+                inner_container_widget_rect,
+                font_id=self.font_id,
+                text_color=self.text_color,
+                text_align=self.text_align,
+                vertical_align="middle",
+            )
+        )
+
+        self._inner_container.add_widget(
+            PkLabelWidget(
+                f"{self.id}_placeholder",
+                self._inner_container,
+                self.placeholder,
+                inner_container_widget_rect,
+                font_id=self.font_id,
+                text_color=self.placeholder_color,
+                text_align=self.text_align,
+                vertical_align="middle",
+            )
+        )
+
+    def on_key_down(self, event: PkEvent) -> None:
+        """Handle key down events.
+
+        Args:
+            event (PkEvent): The key down event.
+        """
+        if self.disabled or not self.focused:
+            return
+
+        if event.key == "backspace":
+            if self.text:
+                self.text = self.text[: self.cursor - 1] + self.text[self.cursor :]
+                self.cursor = max(0, self.cursor - 1)
+        elif event.key == "left":
+            self.cursor = max(0, self.cursor - 1)
+        elif event.key == "right":
+            self.cursor = min(len(self.text), self.cursor + 1)
+        elif event.key == "home":
+            self.cursor = 0
+        elif event.key == "end":
+            self.cursor = len(self.text)
+        elif event.key == "delete":
+            if self.text:
+                self.text = self.text[: self.cursor] + self.text[self.cursor + 1 :]
+        else:
+            if event.unicode.isprintable() and event.unicode != "":
+                if self.max_length == 0 or len(self.text) < self.max_length:
+                    self.text = (
+                        self.text[: self.cursor]
+                        + event.unicode
+                        + self.text[self.cursor :]
+                    )
+                    self.cursor += 1
+        if self.action_on_change:
+            self.action_on_change(self)
+
+    def on_focus(self, event: PkEvent) -> None:
+        """Handle focus events.
+
+        Args:
+            event (PkEvent): The focus event.
+        """
+        if self.disabled:
+            return
+
+        pygame.key.set_repeat(500, 50)
+
+        self.cursor_blink_timer = 0
+        if self.action_on_focus:
+            self.action_on_focus(self)
+
+    def on_unfocus(self, event: PkEvent) -> None:
+        """Handle unfocus events.
+
+        Args:
+            event (PkEvent): The unfocus event.
+        """
+        if self.disabled:
+            return
+
+        pygame.key.set_repeat()
+
+        if self.action_on_unfocus:
+            self.action_on_unfocus(self)
+
+    def on_update(self, delta: float) -> None:
+        """Update the text input widget.
+
+        Args:
+            delta (float): The time since the last update.
+        """
+        if self.disabled:
+            return
+
+        if self.focused:
+            self.cursor_blink_timer += delta
+            if self.cursor_blink_timer >= self.cursor_blink_interval:
+                self.cursor_blink_timer = 0
+
+    def on_render(self) -> None:
+        """Render the text box widget.
+
+        This method is called to render the widget on the screen. It updates
+        the background color, draws the text, and handles placeholder visibility.
+        """
+        if self.disabled:
+            self.surface.fill(self.background_color_disabled)
+            self._inner_container.get_widget(f"{self.id}_placeholder").surface.fill(
+                self.placeholder_color_disabled
+            )
+        else:
+            self.surface.fill(self.background_color)
+            self._inner_container.get_widget(f"{self.id}_placeholder").surface.fill(
+                self.placeholder_color
+            )
+
+        text_with_cursor = self.text
+
+        if self.focused:
+            # self.surface.fill(self.background_color_focused)
+            self._inner_container.get_widget(f"{self.id}_placeholder").surface.fill(
+                self.placeholder_color_focused
+            )
+            cursor = self.cursor_chars[
+                int(
+                    self.cursor_blink_timer
+                    // (self.cursor_blink_interval / len(self.cursor_chars))
+                )
+                % len(self.cursor_chars)
+            ]
+            text_with_cursor = (
+                self.text[: self.cursor] + cursor + self.text[self.cursor :]
+            )
+
+        if self.text != "" or self.focused:
+            self._inner_container.get_widget(f"{self.id}_text").set_text(
+                text_with_cursor
+            )
+            self._inner_container.get_widget(f"{self.id}_text").visible = True
+            self._inner_container.get_widget(f"{self.id}_placeholder").visible = False
+        else:
+            self._inner_container.get_widget(f"{self.id}_text").set_text("")
+            self._inner_container.get_widget(f"{self.id}_text").visible = False
+            self._inner_container.get_widget(f"{self.id}_placeholder").visible = True
+
+        self._inner_container.render()

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -105,6 +105,22 @@ class PkWidget(PkObject):
         self._pressed = False
 
     @property
+    def hovered(self) -> bool:
+        return self._hovered
+
+    @hovered.setter
+    def hovered(self, value: bool) -> None:
+        self._hovered = value
+
+    @property
+    def pressed(self) -> bool:
+        return self._pressed
+
+    @pressed.setter
+    def pressed(self, value: bool) -> None:
+        self._pressed = value
+
+    @property
     def focused(self) -> bool:
         return self._focused
 

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -24,6 +24,8 @@ class PkWidget(PkObject):
         id_: str,
         container: PkContainer,
         rect: PkRect | RectValue,
+        *,
+        focusable: bool = False,
     ):
         """Initialize the widget.
 
@@ -32,6 +34,8 @@ class PkWidget(PkObject):
             container (PkContainer): The container that the widget belongs to.
             rect (PkRect | RectValue): The rectangle that the widget occupies.
                 Relative to the container.
+            focusable (bool): Whether the widget can be focused.
+                Defaults to False.
         """
         super().__init__()
         self.id: str = id_
@@ -81,6 +85,7 @@ class PkWidget(PkObject):
         self._last_mouse_pos: tuple[int, int] = (0, 0)
 
         self._visible: bool = True
+        self._focusable: bool = focusable
         self._disabled: bool = False
         self._hovered: bool = False
         self._pressed: bool = False
@@ -93,6 +98,18 @@ class PkWidget(PkObject):
     @visible.setter
     def visible(self, value: bool) -> None:
         self._visible = value
+
+    @property
+    def focusable(self) -> bool:
+        return self._focusable
+
+    @focusable.setter
+    def focusable(self, value: bool) -> None:
+        self._focusable = value
+        if not value:
+            self._focused = False
+            self._pressed = False
+            self._hovered = False
 
     @property
     def disabled(self) -> bool:
@@ -114,7 +131,7 @@ class PkWidget(PkObject):
 
     @property
     def pressed(self) -> bool:
-        return self._pressed
+        return self._pressed and self._focused
 
     @pressed.setter
     def pressed(self, value: bool) -> None:
@@ -126,7 +143,8 @@ class PkWidget(PkObject):
 
     @focused.setter
     def focused(self, value: bool) -> None:
-        self._focused = value
+        # if the widget is not focusable, set the focused state to False
+        self._focused = value and self.focusable
 
     def on_key_down(self, event: PkEvent) -> None:  # pragma: no cover
         """Handle the key down event.

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -295,29 +295,29 @@ class PkWidget(PkObject):
                 if self.abs_rect.collidepoint(event.pos):
                     if not self.abs_rect.collidepoint(self._last_mouse_pos):
                         self.on_mouse_enter(event)
-                    self._hovered = True
+                    self.hovered = True
                     self.on_hover(event)
                 else:
                     if self.abs_rect.collidepoint(self._last_mouse_pos):
                         self.on_mouse_leave(event)
-                    self._hovered = False
+                    self.hovered = False
                 self._last_mouse_pos = event.pos
             elif event.name == "MOUSEBUTTONDOWN":
                 if self.abs_rect.collidepoint(event.pos):
                     self.on_mouse_down(event)
                     self.on_focus(event)
-                    self._focused = True
-                    self._pressed = True
+                    self.focused = True
+                    self.pressed = True
                 else:
                     self.on_unfocus(event)
-                    self._focused = False
-                    self._pressed = False
+                    self.focused = False
+                    self.pressed = False
             elif event.name == "MOUSEBUTTONUP":
                 if self.abs_rect.collidepoint(event.pos):
                     self.on_mouse_up(event)
-                    self._pressed = False
+                    self.pressed = False
                 else:
-                    self._pressed = False
+                    self.pressed = False
 
         self.on_update(delta)
 

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -284,6 +284,6 @@ class PkWidget(PkObject):
         NOTE: Do not override this method. Instead, override `on_render`.
         """
         self.on_render()
-        if self.focused:
+        if self.focused:  # pragma: no cover
             self.surface.fill("#0000FF")
         self.container.surface.blit(self.surface, self.rect.pos)

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -79,10 +79,20 @@ class PkWidget(PkObject):
         self.surface: PkSurface = PkSurface(self.rect.size, transparent=True)
 
         self._last_mouse_pos: tuple[int, int] = (0, 0)
+
+        self._visible: bool = True
         self._disabled: bool = False
         self._hovered: bool = False
         self._pressed: bool = False
         self._focused: bool = False
+
+    @property
+    def visible(self) -> bool:
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool) -> None:
+        self._visible = value
 
     @property
     def disabled(self) -> bool:
@@ -283,6 +293,9 @@ class PkWidget(PkObject):
         This internal method is called every frame to render the widget.
         NOTE: Do not override this method. Instead, override `on_render`.
         """
+        if not self.visible:
+            return
+
         self.on_render()
         if self.focused:  # pragma: no cover
             self.surface.fill("#0000FF")

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -41,10 +41,7 @@ class PkWidget(PkObject):
         self.id: str = id_
         self.container: PkContainer = container
 
-        if isinstance(rect, PkRect):
-            self.rect: PkRect = rect
-        else:
-            self.rect: PkRect = PkRect.from_tuple(rect)
+        self.rect: PkRect = PkRect.from_value(rect)
 
         # check if the widget is out of bounds
         if self.rect.x < 0:

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -82,6 +82,7 @@ class PkWidget(PkObject):
         self._disabled: bool = False
         self._hovered: bool = False
         self._pressed: bool = False
+        self._focused: bool = False
 
     @property
     def disabled(self) -> bool:
@@ -92,6 +93,14 @@ class PkWidget(PkObject):
         self._disabled = value
         self._hovered = False
         self._pressed = False
+
+    @property
+    def focused(self) -> bool:
+        return self._focused
+
+    @focused.setter
+    def focused(self, value: bool) -> None:
+        self._focused = value
 
     def on_key_down(self, event: PkEvent) -> None:  # pragma: no cover
         """Handle the key down event.
@@ -174,6 +183,36 @@ class PkWidget(PkObject):
         """
         pass
 
+    def on_focus(self, event: PkEvent) -> None:  # pragma: no cover
+        """Handle the focus event.
+
+        This method is called when the widget is focused.
+
+        Args:
+            event (PkEvent): The focus event.
+        """
+        pass
+
+    def on_unfocus(self, event: PkEvent) -> None:  # pragma: no cover
+        """Handle the unfocus event.
+
+        This method is called when the widget is unfocused.
+
+        Args:
+            event (PkEvent): The unfocus event.
+        """
+        pass
+
+    def on_change(self, event: PkEvent) -> None:  # pragma: no cover
+        """Handle the change event.
+
+        This method is called when the widget's state changes.
+
+        Args:
+            event (PkEvent): The change event.
+        """
+        pass
+
     def on_update(self, delta: float) -> None:  # pragma: no cover
         """Update the widget.
 
@@ -222,8 +261,12 @@ class PkWidget(PkObject):
             elif event.name == "MOUSEBUTTONDOWN":
                 if self.abs_rect.collidepoint(event.pos):
                     self.on_mouse_down(event)
+                    self.on_focus(event)
+                    self._focused = True
                     self._pressed = True
                 else:
+                    self.on_unfocus(event)
+                    self._focused = False
                     self._pressed = False
             elif event.name == "MOUSEBUTTONUP":
                 if self.abs_rect.collidepoint(event.pos):
@@ -241,4 +284,6 @@ class PkWidget(PkObject):
         NOTE: Do not override this method. Instead, override `on_render`.
         """
         self.on_render()
+        if self.focused:
+            self.surface.fill("#0000FF")
         self.container.surface.blit(self.surface, self.rect.pos)

--- a/tests/widget/test_text_input_widget.py
+++ b/tests/widget/test_text_input_widget.py
@@ -1,0 +1,154 @@
+import pytest
+import pygame
+from unittest.mock import Mock, MagicMock
+from puffkit.widget.text_input_widget import PkTextInputWidget
+from puffkit.geometry import PkRect
+from puffkit.font import PkFont
+from puffkit import PkApp, PkSurface
+
+# from puffkit.color import PkBasicPalette
+from puffkit import PkContainer
+
+
+@pytest.fixture
+def mock_container() -> PkContainer:
+    pygame.init()
+    app = MagicMock(spec=PkApp)
+    app.fonts = {"default": PkFont(None, 12)}
+
+    parent_surface = MagicMock(spec=PkSurface)
+    parent_surface.get_width.return_value = 200
+    parent_surface.get_height.return_value = 100
+    container = PkContainer(app, parent_surface, "test_container", (0, 0, 200, 50))
+    return container
+
+
+@pytest.fixture
+def text_input_widget(mock_container):
+    """Fixture to create a PkTextInputWidget instance."""
+    rect = PkRect(0, 0, 200, 50)
+    return PkTextInputWidget(
+        id_="test_widget",
+        container=mock_container,
+        rect=rect,
+        text="",
+        max_length=10,
+        placeholder="Enter text",
+    )
+
+
+@pytest.mark.parametrize(
+    "initial_text, key_event, expected_text",
+    [
+        ("", Mock(key="a", unicode="a"), "a"),
+        ("hello", Mock(key="backspace", unicode=""), "hell"),
+        ("hello", Mock(key="delete", unicode=""), "hello"),
+        ("hello", Mock(key="left", unicode=""), "hello"),
+        ("hello", Mock(key="right", unicode=""), "hello"),
+        ("hello", Mock(key="home", unicode=""), "hello"),
+        ("hello", Mock(key="end", unicode=""), "hello"),
+    ],
+)
+def test_on_key_down(text_input_widget, initial_text, key_event, expected_text):
+    """Test the on_key_down method with various key events."""
+    text_input_widget.focused = True
+    text_input_widget.text = initial_text
+    text_input_widget.cursor = len(initial_text)
+    text_input_widget.on_key_down(key_event)
+    assert text_input_widget.text == expected_text
+
+
+def test_on_key_down_no_focus(text_input_widget):
+    """Test the on_key_down method when the widget is not focused."""
+    text_input_widget.focused = False
+    initial_text = "hello"
+    text_input_widget.text = initial_text
+    text_input_widget.cursor = len(initial_text)
+    text_input_widget.on_key_down(Mock(key="a", unicode="a"))
+    assert text_input_widget.text == initial_text
+
+
+def test_on_key_down_action(text_input_widget):
+    """Test the on_key_down method with an action key."""
+    text_input_widget.focused = True
+    text_input_widget.action_on_change = Mock()
+    initial_text = "hello"
+    text_input_widget.text = initial_text
+    text_input_widget.cursor = len(initial_text)
+    text_input_widget.on_key_down(Mock(key="enter", unicode=""))
+    assert text_input_widget.text == initial_text
+    text_input_widget.action_on_change.assert_called_once_with(text_input_widget)
+
+
+def test_on_focus(text_input_widget):
+    """Test the on_focus method."""
+    mock_event = Mock()
+
+    # widget not disabled
+    text_input_widget.action_on_focus = Mock()
+    text_input_widget.on_focus(mock_event)
+    assert text_input_widget.cursor_blink_timer == 0
+    assert text_input_widget.action_on_focus.called
+
+    # widget disabled
+    text_input_widget.disabled = True
+    text_input_widget.cursor_blink_timer = 0.5
+    text_input_widget.action_on_focus = Mock()
+    text_input_widget.on_focus(mock_event)
+    assert text_input_widget.cursor_blink_timer == 0.5  # ensure the timer is not reset
+    text_input_widget.action_on_focus.assert_not_called()
+
+
+def test_on_unfocus(text_input_widget):
+    """Test the on_unfocus method."""
+    mock_event = Mock()
+
+    # widget not disabled
+    text_input_widget.action_on_unfocus = Mock()
+    text_input_widget.on_unfocus(mock_event)
+    text_input_widget.action_on_unfocus.assert_called_once_with(text_input_widget)
+
+    # widget disabled
+    text_input_widget.disabled = True
+    text_input_widget.action_on_unfocus = Mock()
+    text_input_widget.on_unfocus(mock_event)
+    text_input_widget.action_on_unfocus.assert_not_called()
+
+
+def test_on_update(text_input_widget):
+    """Test the on_update method."""
+    text_input_widget.focused = True
+    text_input_widget.cursor_blink_interval = 0.5
+
+    # simulate the cursor blink timer
+    text_input_widget.on_update(0.3)
+    assert text_input_widget.cursor_blink_timer == 0.3
+
+    # simulate the cursor blink interval being reached
+    text_input_widget.on_update(0.5)
+    assert text_input_widget.cursor_blink_timer == 0
+
+    # pass if disabled
+    text_input_widget.disabled = True
+    text_input_widget.cursor_blink_timer = 0.5
+    text_input_widget.on_update(0.5)
+    assert text_input_widget.cursor_blink_timer == 0.5  # ensure the timer is not reset
+
+
+def test_on_render(text_input_widget):
+    """Test the on_render method."""
+    text_input_widget.text = "hello"
+    text_input_widget.focused = True
+    text_input_widget.on_render()
+
+
+def test_invalid_padding_raises_value_error(mock_container):
+    """Test that invalid padding raises a ValueError."""
+    rect = PkRect(0, 0, 10, 10)
+    with pytest.raises(ValueError, match="Padding is too large for the input field"):
+        PkTextInputWidget(
+            id_="test_widget",
+            container=mock_container,
+            rect=rect,
+            padding=6,
+        )

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -154,6 +154,16 @@ def test_widget_render_calls_on_render_and_blit(mock_container: MagicMock) -> No
     mock_container.surface.blit.assert_called_once_with(widget.surface, widget.rect.pos)
 
 
+def test_widget_render_not_visible(mock_container: MagicMock) -> None:
+    """Test that render method does not call on_render or blit if widget is not visible."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10))
+    widget.visible = False
+    widget.on_render = MagicMock()
+    widget.render()
+    widget.on_render.assert_not_called()
+    mock_container.surface.blit.assert_not_called()
+
+
 def test_widget_disabled(mock_container: MagicMock) -> None:
     """Test that setting disabled property disables the widget."""
     widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10))

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -166,7 +166,17 @@ def test_widget_disabled(mock_container: MagicMock) -> None:
 def test_widget_focused(mock_container: MagicMock) -> None:
     """Test that setting focused property sets the widget as focused."""
     widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10))
+
+    # not focusable
+    assert not widget.focusable
     assert not widget.focused
+    widget.focused = True
+    assert not widget.focused
+    assert not widget._focused
+
+    # focusable
+    widget.focusable = True
+    assert widget.focusable
     widget.focused = True
     assert widget.focused
     assert widget._focused

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -207,3 +207,17 @@ def test_widget_hovered(mock_container: MagicMock) -> None:
     widget.hovered = True
     assert widget.hovered
     assert widget._hovered
+
+
+def test_widget_pressed(mock_container: MagicMock) -> None:
+    """Test that setting pressed property sets the widget as pressed."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10), focusable=True)
+    assert not widget.pressed
+    widget.pressed = True
+    assert not widget.pressed
+    assert widget._pressed
+
+    widget.focused = True
+    widget.pressed = True
+    assert widget.pressed
+    assert widget._pressed

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -82,6 +82,8 @@ def test_widget_update_event_handling(mock_container: MagicMock) -> None:
     widget.on_hover = MagicMock()
     widget.on_mouse_enter = MagicMock()
     widget.on_mouse_leave = MagicMock()
+    widget.on_focus = MagicMock()
+    widget.on_unfocus = MagicMock()
 
     KEYDOWN = MagicMock()
     KEYUP = MagicMock()
@@ -136,6 +138,9 @@ def test_widget_update_event_handling(mock_container: MagicMock) -> None:
     widget.on_mouse_leave.assert_called_once()
     widget.on_mouse_down.assert_called_once()
     widget.on_mouse_up.assert_called_once()
+    widget.on_focus.assert_called_once()
+    widget.on_unfocus.assert_called_once()
+    widget.on_hover.assert_called_once()
 
 
 def test_widget_render_calls_on_render_and_blit(mock_container: MagicMock) -> None:

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -189,3 +189,12 @@ def test_widget_visible(mock_container: MagicMock) -> None:
     widget.visible = False
     assert not widget.visible
     assert not widget._visible
+
+
+def test_widget_focusable(mock_container: MagicMock) -> None:
+    """Test that setting focusable property sets the widget as focusable."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10), focusable=True)
+    assert widget.focusable
+    widget.focusable = False
+    assert not widget.focusable
+    assert not widget._focusable

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -161,3 +161,12 @@ def test_widget_disabled(mock_container: MagicMock) -> None:
     widget.disabled = True
     assert widget.disabled
     assert widget._disabled
+
+
+def test_widget_focused(mock_container: MagicMock) -> None:
+    """Test that setting focused property sets the widget as focused."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10))
+    assert not widget.focused
+    widget.focused = True
+    assert widget.focused
+    assert widget._focused

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -198,3 +198,12 @@ def test_widget_focusable(mock_container: MagicMock) -> None:
     widget.focusable = False
     assert not widget.focusable
     assert not widget._focusable
+
+
+def test_widget_hovered(mock_container: MagicMock) -> None:
+    """Test that setting hovered property sets the widget as hovered."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10), focusable=True)
+    assert not widget.hovered
+    widget.hovered = True
+    assert widget.hovered
+    assert widget._hovered

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -180,3 +180,12 @@ def test_widget_focused(mock_container: MagicMock) -> None:
     widget.focused = True
     assert widget.focused
     assert widget._focused
+
+
+def test_widget_visible(mock_container: MagicMock) -> None:
+    """Test that setting visible property sets the widget as visible."""
+    widget = PkWidget("test", mock_container, PkRect(0, 0, 10, 10))
+    assert widget.visible
+    widget.visible = False
+    assert not widget.visible
+    assert not widget._visible


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [x] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

### Deprecations

- **Deprecated `PkRect.from_tuple()` in favor of `PkRect.from_value()`.**
  The new method also supports `PkRect` as an argument, simply returning it back, removing the need for additional logic in code.

### Text Input Widget – `PkTextInputWidget`

- Added a customizable [Text Input Widget](https://github.com/pufereq/puffkit/commit/151df316454bd0485d0a95d178258e4a32999c93) which allows the user to input one-line strings.
- Introduced PkWidget state properties:
  - `visible` - whether the widget is visible,
  - `disabled` - a disabled widget ignores all interactions with it,
  - `focusable` - whether the widget may be focused,
  - `focused` - True if the widget currently has mouse focus (i.e., the user clicked inside the widget and hasn't clicked elsewhere since).
  - `hovered` - True if the mouse hovers over the widget, set automatically,
  - `pressed` - True if any mouse button is clicked inside the widget and the widget is focusasble, set automatically.
- Added `on_focus()` and `on_unfocus()` hooks to `PkWidget`.

### Event Manager change

- Translates key codes into key names for `KEYDOWN` and `KEYUP` events. [[1]](https://github.com/pufereq/puffkit/commit/ed4d8acc8fe115781f6a314020ef10c7e73a1e1e)

### Miscellaneous

- Replaced deprecated `PkRect.from_tuple()` with `PkRect.from_value()` throughout the codebase.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

### An example `PkTextInputWidget`

![PkTextInputWidget showcase](https://github.com/user-attachments/assets/61546e81-dbc3-45d1-a8a6-02db36843814)

