### PR TITLE
feat: add outline on focused widget

### DIFF
--- a/puffkit/surface.py
+++ b/puffkit/surface.py
@@ -612,37 +612,54 @@ class PkSurface(PkObject):
         border_bottom_left_radius: int = -1,
         border_bottom_right_radius: int = -1,
     ) -> None:
-        """Draw a rectangle on the surface.
+        """Draw a rectangle on the surface, supporting alpha transparency.
 
         Args:
             rect (PkRect | RectValue): Rectangle to draw.
             color (PkColor | ColorValue): Color of the rectangle.
-            width (int, optional): Stroke width of the rectangle.
-                Defaults to 0 (filled).
-            border_radius (int, optional): Radius of the rectangle border.
-                Defaults to -1 (no border radius).
-            border_top_left_radius (int, optional): Radius of the top-left corner.
-                Defaults to -1 (no border radius).
-            border_top_right_radius (int, optional): Radius of the top-right corner.
-                Defaults to -1 (no border radius).
-            border_bottom_left_radius (int, optional): Radius of the bottom-left corner.
-                Defaults to -1 (no border radius).
-            border_bottom_right_radius (int, optional): Radius of the bottom-right corner.
-                Defaults to -1 (no border radius).
+            width (int, optional): Stroke width of the rectangle. Defaults to 0 (filled).
+            border_radius (int, optional): Radius of the rectangle border. Defaults to -1 (no border radius).
+            border_top_left_radius (int, optional): Radius of the top-left corner. Defaults to -1 (no border radius).
+            border_top_right_radius (int, optional): Radius of the top-right corner. Defaults to -1 (no border radius).
+            border_bottom_left_radius (int, optional): Radius of the bottom-left corner. Defaults to -1 (no border radius).
+            border_bottom_right_radius (int, optional): Radius of the bottom-right corner. Defaults to -1 (no border radius).
         """
-        if not isinstance(color, PkColor):
-            color = PkColor.from_value(color)
-        pygame.draw.rect(
-            self.internal_surface,
-            tuple(color),
-            tuple(rect),
-            width,
-            border_radius,
-            border_top_left_radius,
-            border_top_right_radius,
-            border_bottom_left_radius,
-            border_bottom_right_radius,
-        )
+        color = PkColor.from_value(color)
+        rect = PkRect.from_value(rect)
+
+        # handle transparency
+        if color.a != 255:
+            shape_surface = PkSurface(
+                self.size,
+                transparent=True,
+            )
+            pygame.draw.rect(
+                shape_surface.internal_surface,
+                tuple(color),
+                (0, 0, *rect[2:]),
+                width,
+                border_radius,
+                border_top_left_radius,
+                border_top_right_radius,
+                border_bottom_left_radius,
+                border_bottom_right_radius,
+            )
+
+            # blit the shape surface to the main surface
+            self.blit(shape_surface, tuple(rect[:2]))
+        else:
+            # draw opaque rect
+            pygame.draw.rect(
+                self.internal_surface,
+                tuple(color),
+                tuple(rect),
+                width,
+                border_radius,
+                border_top_left_radius,
+                border_top_right_radius,
+                border_bottom_left_radius,
+                border_bottom_right_radius,
+            )
 
     def blit_text(
         self,

--- a/puffkit/widget/widget.py
+++ b/puffkit/widget/widget.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from copy import copy
 from typing import TYPE_CHECKING
 
 from puffkit import PkObject, PkSurface
+from puffkit.color import PkBasicPalette
 from puffkit.geometry import PkRect, RectValue
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -76,6 +78,11 @@ class PkWidget(PkObject):
             self.rect.w,
             self.rect.h,
         )
+
+        self.outer_outline = copy(PkBasicPalette.BLUE)
+        self.outer_outline.a = 127
+        self.inner_outline = copy(PkBasicPalette.BLUE)
+        self.inner_outline.a = 64
 
         self.surface: PkSurface = PkSurface(self.rect.size, transparent=True)
 
@@ -328,6 +335,18 @@ class PkWidget(PkObject):
             return
 
         self.on_render()
-        if self.focused:  # pragma: no cover
-            self.surface.fill("#0000FF")
+        # if focused, draw outline
+        if self.focused:
+            self.surface.draw_rect(
+                (0, 0, self.rect.w, self.rect.h),
+                self.inner_outline,
+                width=1,
+            )
+            outline_rect = self.rect.inflate(2, 2)
+            self.container.surface.draw_rect(
+                outline_rect,
+                self.outer_outline,
+                width=1,
+            )
+
         self.container.surface.blit(self.surface, self.rect.pos)


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

### `PkSurface.draw_rect()` changes

- Added support for alpha colors (i.e. (127, 127, 127, 64) – Gray with 25% opacity) in `PkSurface.draw_rect()`.

### Accesibility

- Added an outline on focused widgets for better visibility.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

### Showcase of focus outlines

![A showcase of focus outlines.](https://github.com/user-attachments/assets/2833d406-6116-41ad-9b37-6e9babee29fb)

