### PR TITLE
feat(button_widget.py): activate focused button on space/return keypress

### DIFF
--- a/src/puffkit/widget/button_widget.py
+++ b/src/puffkit/widget/button_widget.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from puffkit.color import PkBasicPalette, PkColor, ColorValue
 from puffkit.container import PkContainer
@@ -160,6 +160,17 @@ class PkButtonWidget(PkWidget):
 
         if callable(self.action_on_click) and self._pressed:
             self.action_on_click()
+
+    @override
+    def on_key_down(self, event: PkEvent) -> None:
+        if event.key in ["return", "space"]:
+            self.pressed = True
+            self.on_mouse_up(event)
+
+    @override
+    def on_key_up(self, event: PkEvent) -> None:
+        if event.key in ["return", "space"]:
+            self.pressed = False
 
     def on_hover(self, event: PkEvent) -> None:
         if self._disabled:

--- a/tests/widget/test_button_widget.py
+++ b/tests/widget/test_button_widget.py
@@ -263,3 +263,43 @@ def test_button_on_hover(button_widget: PkButtonWidget, disabled: bool, event: M
         button_widget.action_on_hover.assert_not_called()
     else:
         button_widget.action_on_hover.assert_called_once()
+
+@pytest.mark.parametrize(
+    "disabled, event",
+    [
+        (True, Mock(spec=PkEvent, key="return")),
+        (False, Mock(spec=PkEvent, key="return")),
+        (True, Mock(spec=PkEvent, key="space")),
+        (False, Mock(spec=PkEvent, key="space")),
+        (True, Mock(spec=PkEvent, key="a")),
+        (False, Mock(spec=PkEvent, key="a")),
+    ],
+)
+def test_button_on_key_down(button_widget: PkButtonWidget, disabled: bool, event: Mock):
+    """Test the on_key_down method of the button widget."""
+    button_widget.disabled = disabled
+    button_widget.on_key_down(event)
+    if disabled or event.key not in ["return", "space"]:
+        button_widget.action_on_click.assert_not_called()
+    else:
+        button_widget.action_on_click.assert_called_once()
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        Mock(spec=PkEvent, key="return"),
+        Mock(spec=PkEvent, key="return"),
+        Mock(spec=PkEvent, key="space"),
+        Mock(spec=PkEvent, key="space"),
+        Mock(spec=PkEvent, key="a"),
+        Mock(spec=PkEvent, key="a"),
+    ],
+)
+def test_button_on_key_up(button_widget: PkButtonWidget, event: Mock):
+    """Test the on_key_up method of the button widget."""
+    button_widget._pressed = True
+    button_widget.on_key_up(event)
+    if event.key in ["return", "space"]:
+        assert not button_widget._pressed
+    else:
+        assert button_widget._pressed


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

Accesibility:
- added `on_key_down` and `on_key_up` hooks to `PkButtonWidget` dlass, allowing for pressing the currently focused button with the `enter` or `space` keys.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

![keyboard_button_press](https://github.com/user-attachments/assets/350bd089-9394-4b7d-9c32-dd76ac4ab882)

