### PR TITLE
feat: add image widget

### DIFF
--- a/src/puffkit/image/__init__.py
+++ b/src/puffkit/image/__init__.py
@@ -1,0 +1,3 @@
+from .image import PkImage
+
+__all__ = ["PkImage"]

--- a/src/puffkit/image/image.py
+++ b/src/puffkit/image/image.py
@@ -20,13 +20,16 @@ class PkImage(PkObject):
 
         self.id: str = id_
         self.image: PkSurface = image
+        self.filename: str | None = None
 
     @classmethod
     def from_file(cls, id_: str, file_path: str) -> PkImage:
         image_surface: PkSurface = PkSurface.from_pygame(
             pg.image.load(file_path).convert_alpha()
         )
-        return cls(id_, image_surface)
+        class_ = cls(id_, image_surface)
+        class_.filename = file_path
+        return class_
 
     @override
     def __repr__(self) -> str:  # pragma: no cover

--- a/src/puffkit/image/image.py
+++ b/src/puffkit/image/image.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+import pygame as pg
+
+from puffkit.geometry import PkSize
+from puffkit.object import PkObject
+from puffkit.surface import PkSurface
+
+
+class PkImage(PkObject):
+    def __init__(
+        self,
+        id_: str,
+        image: PkSurface,
+    ) -> None:
+        super().__init__(True)
+
+        self.id: str = id_
+        self.image: PkSurface = image
+
+    @classmethod
+    def from_file(cls, id_: str, file_path: str) -> PkImage:
+        image_surface: PkSurface = PkSurface.from_pygame(
+            pg.image.load(file_path).convert_alpha()
+        )
+        return cls(id_, image_surface)
+
+    @override
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"PkImage(id_={self.id}, size={self.size})"
+
+    @override
+    def __str__(self) -> str:  # pragma: no cover
+        return f"PkImage(id_={self.id}, size={self.size})"
+
+    @property
+    def width(self) -> int | float:  # pragma: no cover
+        return self.image.width
+
+    @property
+    def height(self) -> int | float:  # pragma: no cover
+        return self.image.height
+
+    @property
+    def size(self) -> PkSize:  # pragma: no cover
+        return self.image.size

--- a/src/puffkit/image/image.py
+++ b/src/puffkit/image/image.py
@@ -11,11 +11,19 @@ from puffkit.surface import PkSurface
 
 
 class PkImage(PkObject):
+    """Represents an image in puffkit."""
+
     def __init__(
         self,
         id_: str,
         image: PkSurface,
     ) -> None:
+        """Initialize a PkImage.
+
+        Args:
+            id_ (str): The unique identifier for the image.
+            image (PkSurface): The surface representing the image.
+        """
         super().__init__(True)
 
         self.id: str = id_
@@ -24,6 +32,15 @@ class PkImage(PkObject):
 
     @classmethod
     def from_file(cls, id_: str, file_path: str) -> PkImage:
+        """Create a PkImage from a file.
+
+        Args:
+            id_ (str): The unique identifier for the image.
+            file_path (str): The path to the image file.
+
+        Returns:
+            PkImage: The created PkImage instance.
+        """
         image_surface: PkSurface = PkSurface.from_pygame(
             pg.image.load(file_path).convert_alpha()
         )

--- a/src/puffkit/surface.py
+++ b/src/puffkit/surface.py
@@ -755,3 +755,28 @@ class PkSurface(PkObject):
         text_surface.blit(rendered_text, (0, y_pos))
 
         self.blit(text_surface, rect.pos)
+
+    def resize(
+        self, size: PkSize | SizeValue, *, smooth: bool = True
+    ) -> PkSurface:
+        """Resize the surface and return a new surface.
+
+        Args:
+            size (PkSize | SizeValue): New size of the surface.
+            smooth (bool, optional): Whether to use smooth scaling.
+                Defaults to True.
+
+        Returns:
+            Surface: Resized surface.
+        """
+        if not isinstance(size, PkSize):
+            size = PkSize(*size)
+        if smooth:
+            resized_surface = pygame.transform.smoothscale(
+                self.internal_surface, size.tuple
+            )
+        else:
+            resized_surface = pygame.transform.scale(
+                self.internal_surface, size.tuple
+            )
+        return self.from_pygame(resized_surface)

--- a/src/puffkit/widget/__init__.py
+++ b/src/puffkit/widget/__init__.py
@@ -3,10 +3,12 @@ from .widget import PkWidget
 from .label_widget import PkLabelWidget
 from .button_widget import PkButtonWidget
 from .text_input_widget import PkTextInputWidget
+from .image_widget import PkImageWidget
 
 __all__ = [
     "PkWidget",
     "PkLabelWidget",
     "PkButtonWidget",
     "PkTextInputWidget",
+    "PkImageWidget",
 ]

--- a/src/puffkit/widget/image_widget.py
+++ b/src/puffkit/widget/image_widget.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Final, override
+
+from puffkit.color import ColorValue, PkBasicPalette, PkColor
+from puffkit.container import PkContainer
+from puffkit.event.event import PkEvent
+from puffkit.geometry import PkSize
+from puffkit.image import PkImage
+from puffkit.surface import PkSurface
+from puffkit.widget import PkWidget
+
+if TYPE_CHECKING:  # pragma: no cover
+    from puffkit.geometry import PkRect, RectValue
+
+
+class PkImageWidget(PkWidget):
+    """A widget that displays an image with various resizing options."""
+
+    RESIZE_MODES: set[str | None] = {"stretch", "fit", "fill", "tile", None}
+
+    def __init__(
+        self,
+        id_: str,
+        container: PkContainer,
+        image: PkImage,
+        rect: PkRect | RectValue,
+        resize_mode: str | None = "stretch",
+        *,
+        click_hook: Callable[[PkImageWidget, PkEvent], None] | None = None,
+        hover_hook: Callable[[PkImageWidget, PkEvent], None] | None = None,
+        disabled: bool = False,
+        background_color: PkColor | ColorValue = PkBasicPalette.TRANSPARENT,
+        border_radius: int = 0,
+    ) -> None:
+        """Initialize a PkImageWidget.
+        Args:
+            id_ (str): The ID of the image widget.
+            container (PkContainer): The container that the widget belongs to.
+            image (PkImage): The image to display in the widget.
+            rect (PkRect | RectValue): The rectangle that the widget occupies.
+                Relative to the container.
+            resize_mode (str | None, optional): The resize mode for the image.
+                Options are "stretch", "fit", "fill", "tile", and None.
+                Defaults to "stretch".
+            click_hook (Callable[[PkImageWidget, PkEvent], None] | None, optional):
+                The action to perform when the widget is clicked. Defaults to None.
+            hover_hook (Callable[[PkImageWidget, PkEvent], None] | None, optional):
+                The action to perform when the widget is hovered. Defaults to None.
+            disabled (bool, optional): Whether the widget is disabled. Defaults to False.
+            background_color (PkColor | ColorValue, optional): The background color
+                of the widget. Defaults to transparent.
+            border_radius (int, optional): The border radius of the widget. Defaults to 0.
+        """
+        if resize_mode not in self.RESIZE_MODES:
+            raise ValueError(
+                f"Invalid resize mode: {resize_mode}. "
+                + f"Valid options are: {self.RESIZE_MODES}",
+            )
+        super().__init__(id_, container, rect, focusable=False)
+
+        self._image: PkImage = image
+
+        self.click_hook: Callable[[PkImageWidget, PkEvent], None] | None = (
+            click_hook
+        )
+        self.hover_hook: Callable[[PkImageWidget, PkEvent], None] | None = (
+            hover_hook
+        )
+        self._disabled: bool = disabled
+
+        self.background_color: PkColor = PkColor.from_value(background_color)
+        self.border_radius: int = border_radius
+        self.resize_mode: str | None = resize_mode
+
+        self.resized_image: PkImage = self._resize_image(self.resize_mode)
+
+    @property
+    def image(self) -> PkImage:  # pragma: no cover
+        """The image displayed in the widget."""
+        return self._image
+
+    @image.setter
+    def image(self, new_image: PkImage) -> None:
+        """Set a new image for the widget and update the resized image."""
+        self._image = new_image
+        self.resized_image = self._resize_image(self.resize_mode)
+
+    @override
+    def __str__(self) -> str:  # pragma: no cover
+        return (
+            f"PkImageWidget(id_={self.id}, rect={self.rect}, "
+            f"image={self.image}, resize_mode={self.resize_mode})"
+        )
+
+    @override
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"PkImageWidget(id_={self.id}, rect={self.rect}, "
+            f"image={self.image}, resize_mode={self.resize_mode})"
+        )
+
+    def _resize_image(self, resize_mode: str | None = None) -> PkImage:
+        """Resize the image according to the resize mode.
+
+        Args:
+            resize_mode (str | None, optional): The resize mode to use.
+                If None, use the widget's resize mode. Defaults to None.
+
+        Returns:
+            PkImage: The resized image.
+        """
+        match resize_mode:
+            case "stretch":
+                resized_surface = self.image.image.resize(
+                    self.rect.size,
+                )
+                return PkImage(self.image.id, resized_surface)
+            case "fit":
+                # maintain aspect ratio
+                image_aspect_ratio = self.image.width / self.image.height
+                rect_aspect_ratio = self.rect.width / self.rect.height
+                if image_aspect_ratio > rect_aspect_ratio:
+                    # fit to width
+                    new_width = self.rect.width
+                    new_height = new_width / image_aspect_ratio
+                else:
+                    # fit to height
+                    new_height = self.rect.height
+                    new_width = new_height * image_aspect_ratio
+                resized_surface = self.image.image.resize(
+                    (int(new_width), int(new_height)),
+                )
+                return PkImage(self.image.id, resized_surface)
+            case "fill":
+                # maintain aspect ratio, cover entire rect
+                image_aspect_ratio = self.image.width / self.image.height
+                rect_aspect_ratio = self.rect.width / self.rect.height
+                if image_aspect_ratio < rect_aspect_ratio:
+                    # cover width
+                    new_width = self.rect.width
+                    new_height = new_width / image_aspect_ratio
+                else:
+                    # cover height
+                    new_height = self.rect.height
+                    new_width = new_height * image_aspect_ratio
+                resized_surface = self.image.image.resize(
+                    (int(new_width), int(new_height)),
+                )
+                return PkImage(self.image.id, resized_surface)
+            case "tile":
+                surface: PkSurface = PkSurface(
+                    self.rect.size, transparent=True
+                )
+                for x in range(0, int(self.rect.width), int(self.image.width)):
+                    for y in range(
+                        0, int(self.rect.height), int(self.image.height)
+                    ):
+                        surface.blit(self.image.image, (x, y))
+                return PkImage(self.image.id, surface)
+            case None:
+                return self.image
+            case _:
+                raise ValueError(
+                    f"Invalid resize mode: {resize_mode}. "
+                    + f"Valid options are: {self.RESIZE_MODES}",
+                )
+
+    @override
+    def on_click(self, event: PkEvent) -> None:
+        if callable(self.click_hook):
+            self.click_hook(self, event)
+
+    @override
+    def on_hover(self, event: PkEvent) -> None:
+        if callable(self.hover_hook):
+            self.hover_hook(self, event)
+
+    @override
+    def on_render(self) -> None:
+        # fill the surface with a background color
+        self.surface.fill(self.background_color)
+
+        # draw the image at the center of the widget
+        image_x = (self.rect.width - self.resized_image.width) // 2
+        image_y = (self.rect.height - self.resized_image.height) // 2
+        self.surface.blit(self.resized_image.image, (image_x, image_y))

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -15,6 +15,7 @@ def test_image_properties(mock_image: PkImage) -> None:
     assert mock_image.id == "test_image"
     assert mock_image.width == 100
     assert mock_image.height == 100
+    assert mock_image.filename is None
     assert isinstance(mock_image.image, PkSurface)
 
 @unittest.mock.patch("puffkit.image.image.pg.image.load")
@@ -27,5 +28,6 @@ def test_image_from_file(mock_pygame_load: MagicMock) -> None:
     assert image.id == "file_image"
     assert image.width == 50
     assert image.height == 50
+    assert image.filename == "path/to/image.png"
     mock_pygame_load.assert_called_once_with("path/to/image.png")
 

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+import unittest.mock
+import pygame as pg
+import pytest
+
+from puffkit.image import PkImage
+from puffkit.surface import PkSurface
+
+@pytest.fixture
+def mock_image() -> PkImage:
+    surface: PkSurface = PkSurface((100, 100))
+    return PkImage("test_image", surface)
+
+def test_image_properties(mock_image: PkImage) -> None:
+    assert mock_image.id == "test_image"
+    assert mock_image.width == 100
+    assert mock_image.height == 100
+    assert isinstance(mock_image.image, PkSurface)
+
+@unittest.mock.patch("puffkit.image.image.pg.image.load")
+def test_image_from_file(mock_pygame_load: MagicMock) -> None:
+    mock_surface = pg.Surface((50, 50))
+    mock_pygame_load.return_value = mock_surface
+
+    image = PkImage.from_file("file_image", "path/to/image.png")
+
+    assert image.id == "file_image"
+    assert image.width == 50
+    assert image.height == 50
+    mock_pygame_load.assert_called_once_with("path/to/image.png")
+

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -463,6 +463,16 @@ def test_pksurface_blit_text(
     )
 
 
+@pytest.mark.parametrize(
+    "smooth",
+    [False, True],
+)
+def test_pksurface_resize(surface: PkSurface, smooth: bool) -> None:
+    """Test resizing the surface."""
+    resized_surface: PkSurface = surface.resize((150, 150), smooth=smooth)
+    assert resized_surface.size == (150, 150)
+
+
 @mock.patch("typing.TYPE_CHECKING", True)
 def test_type_checking_imports() -> None:
     """Test importing PkSurface with TYPE_CHECKING."""

--- a/tests/widget/test_image_widget.py
+++ b/tests/widget/test_image_widget.py
@@ -1,0 +1,125 @@
+from itertools import product
+from unittest.mock import MagicMock, NonCallableMagicMock
+import unittest.mock
+import pygame as pg
+import pytest
+
+from puffkit.app import PkApp
+from puffkit.image import PkImage
+from puffkit.widget.image_widget import PkImageWidget
+from puffkit.surface import PkSurface
+from puffkit.geometry import PkRect
+from puffkit.container import PkContainer
+
+@pytest.fixture
+def image_widget() -> PkImageWidget:
+    surface: PkSurface = PkSurface((100, 100))
+    mock_image = MagicMock(spec=PkImage)
+    mock_image.id = "test_image"
+    mock_image.image = surface
+    mock_image.width = 100
+    mock_image.height = 100
+
+    mock_container = MagicMock(spec=PkContainer)
+    mock_container.rect = PkRect(0, 0, 100, 100)
+    rect = PkRect(0, 0, 100, 100)
+
+    return PkImageWidget(
+        id_="test_widget",
+        container=mock_container,
+        image=mock_image,
+        rect=rect,
+        resize_mode="stretch",
+    )
+
+
+def test_image_widget_init(image_widget: PkImageWidget) -> None:
+    assert image_widget.id == "test_widget"
+    assert image_widget.container == image_widget.container
+    assert image_widget.image == image_widget.image
+    assert image_widget.rect == image_widget.rect
+    assert image_widget.resize_mode == "stretch"
+    assert isinstance(image_widget.resized_image, PkImage)
+
+
+def test_image_widget_invalid_resize_mode(image_widget: PkImageWidget) -> None:
+    with pytest.raises(ValueError):
+        _ = PkImageWidget(
+            id_="invalid_widget",
+            container=image_widget.container,
+            image=image_widget.image,
+            rect=image_widget.rect,
+            resize_mode="INVALID_MODE",
+        )
+
+
+@pytest.mark.parametrize("resize_mode, new_size", product(
+    [None, "stretch", "fit", "fill", "tile"],
+    [(200, 150), (150, 200), (50, 50), (300, 300)],
+))
+def test_image_widget_resize_mode(image_widget: PkImageWidget, resize_mode: str | None, new_size: tuple[int, int]) -> None:
+    image_widget.rect = PkRect(0, 0, new_size[0], new_size[1])
+    resized_image = image_widget._resize_image(resize_mode)
+    assert isinstance(resized_image, PkImage)
+    assert resized_image.id == image_widget.image.id
+
+    if resize_mode == "stretch":
+        assert resized_image.image.size == new_size
+    elif resize_mode == "fit":
+        assert resized_image.image.width <= new_size[0]
+        assert resized_image.image.height <= new_size[1]
+    elif resize_mode == "fill":
+        assert resized_image.image.width >= new_size[0]
+        assert resized_image.image.height >= new_size[1]
+    elif resize_mode == "tile":
+        assert resized_image.image.size == new_size
+    elif resize_mode is None:
+        assert resized_image.image.size == (100, 100)  # original size
+
+def test_image_widget_resize_mode_invalid(image_widget: PkImageWidget) -> None:
+    with pytest.raises(ValueError):
+        image_widget._resize_image("INVALID_MODE")
+
+
+def test_image_widget_image_property_setter(image_widget: PkImageWidget) -> None:
+    new_surface: PkSurface = PkSurface((50, 50))
+    new_image = PkImage("new_image", new_surface)
+    image_widget.image = new_image
+    assert image_widget.image == new_image
+    assert image_widget.image.image.size == new_surface.size
+    assert image_widget.resized_image.image.size == image_widget.rect.size
+
+
+def test_image_widget_on_click_no_hook(image_widget: PkImageWidget) -> None:
+    mock_event = MagicMock()
+
+    image_widget.click_hook = NonCallableMagicMock()
+    image_widget.on_click(mock_event)  # should do nothing
+    image_widget.click_hook.assert_not_called()
+
+def test_image_widget_on_click_with_hook(image_widget: PkImageWidget) -> None:
+    mock_event = MagicMock()
+
+    image_widget.click_hook = MagicMock(return_value=None)
+    image_widget.on_click(mock_event)
+    image_widget.click_hook.assert_called_once_with(image_widget, mock_event)
+
+
+def test_image_widget_on_hover_no_hook(image_widget: PkImageWidget) -> None:
+    mock_event = MagicMock()
+
+    image_widget.hover_hook = NonCallableMagicMock()
+    image_widget.on_hover(mock_event)  # should do nothing
+    image_widget.hover_hook.assert_not_called()
+
+def test_image_widget_on_hover_with_hook(image_widget: PkImageWidget) -> None:
+    mock_event = MagicMock()
+
+    image_widget.hover_hook = MagicMock(return_value=None)
+    image_widget.on_hover(mock_event)
+    image_widget.hover_hook.assert_called_once_with(image_widget, mock_event)
+
+
+def test_image_widget_on_render(image_widget: PkImageWidget) -> None:
+    # ensure no exceptions are raised
+    image_widget.on_render()


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [x] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [x] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds an Image Widget with support of five resize modes: stretch, fill, fit, tile, and none.
- Adds `PkSurface.resize()` method.
- Adds `PkImage` class, representing an image, which can be loaded from a surface or a file.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

_replace this line with instructions (screenshots) on how to test, use your changes_
