### PR TITLE
fix/62

### DIFF
--- a/src/puffkit/geometry/coordinate.py
+++ b/src/puffkit/geometry/coordinate.py
@@ -39,11 +39,11 @@ class PkCoordinate:
         """
         return (self.x, self.y)
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no cover
         """Return a human-friendly representation of the coordinate."""
         return f"({self.x}, {self.y})"
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         """Return a string representation of the coordinate."""
         return f"PkCoordinate({self.x}, {self.y})"
 

--- a/src/puffkit/geometry/coordinate.py
+++ b/src/puffkit/geometry/coordinate.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Iterable
 
 
-type CoordinateValue = tuple[int | float, int | float]
+type CoordinateValue = tuple[float, float]
 
 
 class PkCoordinate:
@@ -20,12 +20,12 @@ class PkCoordinate:
     The class is used to represent positions of objects on the screen.
     """
 
-    def __init__(self, x: int | float, y: int | float) -> None:
+    def __init__(self, x: float, y: float) -> None:
         """Initialize the coordinate.
 
         Args:
-            x (int | float): X coordinate.
-            y (int | float): Y coordinate.
+            x (float): X coordinate.
+            y (float): Y coordinate.
         """
         self.x = x
         self.y = y
@@ -92,7 +92,7 @@ class PkCoordinate:
         """
         return PkCoordinate(self.x // other, self.y // other)
 
-    def to_tuple(self) -> tuple[int | float, int | float]:
+    def to_tuple(self) -> tuple[float, float]:
         """Return the coordinate as a tuple.
 
         Returns:
@@ -111,24 +111,20 @@ class PkCoordinate:
         """
         return ((self.x - other.x) ** 2 + (self.y - other.y) ** 2) ** 0.5
 
-    def __eq__(
-        self, other: PkCoordinate | tuple[int | float, int | float]
-    ) -> bool:
+    def __eq__(self, other: PkCoordinate | tuple[float, float]) -> bool:
         if not isinstance(other, PkCoordinate):
             other = PkCoordinate(*other)
         return self.x == other.x and self.y == other.y
 
-    def __ne__(
-        self, other: PkCoordinate | tuple[int | float, int | float]
-    ) -> bool:
+    def __ne__(self, other: PkCoordinate | tuple[float, float]) -> bool:
         if not isinstance(other, PkCoordinate):
             other = PkCoordinate(*other)
         return self.x != other.x or self.y != other.y
 
-    def __iter__(self) -> Iterable[int | float]:
+    def __iter__(self) -> Iterable[float]:
         return iter((self.x, self.y))
 
-    def __getitem__(self, index: int) -> int | float:
+    def __getitem__(self, index: int) -> float:
         return (self.x, self.y)[index]
 
     @classmethod

--- a/src/puffkit/geometry/coordinate.py
+++ b/src/puffkit/geometry/coordinate.py
@@ -27,8 +27,8 @@ class PkCoordinate:
             x (float): X coordinate.
             y (float): Y coordinate.
         """
-        self.x = x
-        self.y = y
+        self.x: float = float(x)
+        self.y: float = float(y)
 
     @property
     def tuple(self) -> CoordinateValue:

--- a/src/puffkit/geometry/rect.py
+++ b/src/puffkit/geometry/rect.py
@@ -35,12 +35,14 @@ class PkRect:
             w (float): The width of the rectangle.
             h (float): The height of the rectangle.
         """
-        self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
+        self.logger: lg.Logger = lg.getLogger(
+            f"{__name__}.{self.__class__.__name__}"
+        )
 
-        self.x: float = x
-        self.y: float = y
-        self.w: float = w
-        self.h: float = h
+        self.x: float = float(x)
+        self.y: float = float(y)
+        self.w: float = float(w)
+        self.h: float = float(h)
 
     @classmethod
     def from_value(cls, rect: RectValue | PkRect) -> PkRect:

--- a/src/puffkit/geometry/rect.py
+++ b/src/puffkit/geometry/rect.py
@@ -7,7 +7,7 @@ import logging as lg
 
 import pygame
 
-type RectValue = tuple[int | float, int | float, int | float, int | float]
+type RectValue = tuple[float, float, float, float]
 
 
 class PkRect:

--- a/src/puffkit/geometry/rect.py
+++ b/src/puffkit/geometry/rect.py
@@ -7,12 +7,10 @@ import logging as lg
 
 import pygame
 
-from puffkit.object import PkObject
-
 type RectValue = tuple[int | float, int | float, int | float, int | float]
 
 
-class PkRect(PkObject):
+class PkRect:
     """Rectangle class.
 
     A rectangle is defined by its top-left corner and its size. It is used to

--- a/src/puffkit/geometry/size.py
+++ b/src/puffkit/geometry/size.py
@@ -27,8 +27,9 @@ class PkSize:
             w (float): Width of the size.
             h (float): Height of the size.
         """
-        self.w = w
-        self.h = h
+
+        self.w: float = float(w)
+        self.h: float = float(h)
 
     @classmethod
     def from_tuple(cls, size: SizeValue) -> PkSize:

--- a/src/puffkit/geometry/size.py
+++ b/src/puffkit/geometry/size.py
@@ -58,11 +58,11 @@ class PkSize:
         """Return the size as a tuple."""
         return (self.w, self.h)
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no cover
         """Return a human-friendly representation of the size."""
         return f"({self.w}, {self.h})"
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         """Return a string representation of the size."""
         return f"PkSize({self.w}, {self.h})"
 

--- a/src/puffkit/geometry/size.py
+++ b/src/puffkit/geometry/size.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Iterable
 
 
-type SizeValue = tuple[int | float, int | float]
+type SizeValue = tuple[float, float]
 
 
 class PkSize:
@@ -20,12 +20,12 @@ class PkSize:
     The class is used to represent the size of objects on the screen.
     """
 
-    def __init__(self, w: int | float, h: int | float) -> None:
+    def __init__(self, w: float, h: float) -> None:
         """Initialize the size.
 
         Args:
-            w (int | float): Width of the size.
-            h (int | float): Height of the size.
+            w (float): Width of the size.
+            h (float): Height of the size.
         """
         self.w = w
         self.h = h
@@ -35,7 +35,7 @@ class PkSize:
         """Create a size from a tuple.
 
         Args:
-            size (tuple[int | float, int | float]): The size as a tuple.
+            size (tuple[float, float]): The size as a tuple.
 
         Returns:
             PkSize: The size object.
@@ -43,17 +43,17 @@ class PkSize:
         return cls(*size)
 
     @property
-    def width(self) -> int | float:
+    def width(self) -> float:
         """Return the width of the size."""
         return self.w
 
     @property
-    def height(self) -> int | float:
+    def height(self) -> float:
         """Return the height of the size."""
         return self.h
 
     @property
-    def tuple(self) -> tuple[int | float, int | float]:
+    def tuple(self) -> tuple[float, float]:
         """Return the size as a tuple."""
         return (self.w, self.h)
 
@@ -65,11 +65,11 @@ class PkSize:
         """Return a string representation of the size."""
         return f"PkSize({self.w}, {self.h})"
 
-    def __eq__(self, other: PkSize | tuple[int | float, int | float]) -> bool:
+    def __eq__(self, other: PkSize | tuple[float, float]) -> bool:
         """Compare two sizes for equality.
 
         Args:
-            other (PkSize | tuple[int | float, int | float]): The other size to compare.
+            other (PkSize | tuple[float, float]): The other size to compare.
         Returns:
             bool: True if the sizes are equal, False otherwise.
         """
@@ -77,7 +77,7 @@ class PkSize:
             other = PkSize(*other)
         return self.w == other.w and self.h == other.h
 
-    def __ne__(self, other: PkSize | tuple[int | float, int | float]) -> bool:
+    def __ne__(self, other: PkSize | tuple[float, float]) -> bool:
         """Compare two sizes for inequality.
 
         Args:
@@ -134,10 +134,10 @@ class PkSize:
         """
         return PkSize(self.w // other, self.h // other)
 
-    def __iter__(self) -> Iterable[int | float]:
+    def __iter__(self) -> Iterable[float]:
         """Return an iterable of the size components."""
         return iter((self.w, self.h))
 
-    def __getitem__(self, index: int) -> int | float:
+    def __getitem__(self, index: int) -> float:
         """Return the size component at the given index."""
         return (self.w, self.h)[index]

--- a/tests/geometry/test_coordinate.py
+++ b/tests/geometry/test_coordinate.py
@@ -3,32 +3,6 @@ import pytest
 from puffkit.geometry.coordinate import PkCoordinate
 
 
-@pytest.mark.parametrize(
-    "x, y, expected_str",
-    [
-        (1, 2, "(1, 2)"),
-        (0, 0, "(0, 0)"),
-        (-1, -2, "(-1, -2)"),
-    ],
-)
-def test_str(x: int, y: int, expected_str: str) -> None:
-    """Test the __str__ method of PkCoordinate."""
-    coord = PkCoordinate(x, y)
-    assert str(coord) == expected_str
-
-
-@pytest.mark.parametrize(
-    "x, y, expected_repr",
-    [
-        (1, 2, "PkCoordinate(1, 2)"),
-        (0, 0, "PkCoordinate(0, 0)"),
-        (-1, -2, "PkCoordinate(-1, -2)"),
-    ],
-)
-def test_repr(x: int, y: int, expected_repr: str) -> None:
-    """Test the __repr__ method of PkCoordinate."""
-    coord = PkCoordinate(x, y)
-    assert repr(coord) == expected_repr
 
 
 @pytest.mark.parametrize(

--- a/tests/geometry/test_rect.py
+++ b/tests/geometry/test_rect.py
@@ -3,22 +3,6 @@ import pytest
 from puffkit.geometry.rect import PkRect, RectValue
 
 
-@pytest.mark.parametrize(
-    "x, y, w, h, expected_repr",
-    [
-        (0, 0, 10, 10, "PkRect(0, 0, 10, 10)"),
-        (-5, -5, 15, 15, "PkRect(-5, -5, 15, 15)"),
-        (1, 1, 2, 2, "PkRect(1, 1, 2, 2)"),
-        (-10, -10, 20, 20, "PkRect(-10, -10, 20, 20)"),
-    ],
-)
-def test_pkrect_repr(
-    x: float, y: float, w: float, h: float, expected_repr: str
-) -> None:
-    """Test the __repr__ method of PkRect."""
-    rect = PkRect(x, y, w, h)
-    assert repr(rect) == expected_repr
-
 
 @pytest.mark.parametrize(
     "x, y, w, h, point, expected_result",

--- a/tests/geometry/test_size.py
+++ b/tests/geometry/test_size.py
@@ -10,32 +10,6 @@ def test_pksize_from_tuple() -> None:
     assert size.h == 20
 
 
-@pytest.mark.parametrize(
-    "w, h, expected_str",
-    [
-        (10, 20, "(10, 20)"),
-        (0, 0, "(0, 0)"),
-        (-5, 15, "(-5, 15)"),
-    ],
-)
-def test_pksize_str(w: int, h: int, expected_str: str) -> None:
-    """Test the __str__ method of PkSize."""
-    size = PkSize(w, h)
-    assert str(size) == expected_str
-
-
-@pytest.mark.parametrize(
-    "w, h, expected_repr",
-    [
-        (10, 20, "PkSize(10, 20)"),
-        (0, 0, "PkSize(0, 0)"),
-        (-5, 15, "PkSize(-5, 15)"),
-    ],
-)
-def test_pksize_repr(w: int, h: int, expected_repr: str) -> None:
-    """Test the __repr__ method of PkSize."""
-    size = PkSize(w, h)
-    assert repr(size) == expected_repr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## PR type (check all applicable)

- [ ] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [x] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Ensures `PkRect`, `PkCoordinate` and `PkSize` always use floats
- Removes `PkRect`'s, `PkCoordinate`'s and `PkSize`'s `__str__` and `__repr__` from coverage and tests

## Related Tickets

- related issue #
- closes #62 

## Instructions, Screenshots

_replace this line with instructions (screenshots) on how to test, use your changes_
