### PR TITLE
fix(container.py): use `id` instead of `name` in `PkContainer`

### DIFF
--- a/src/puffkit/container.py
+++ b/src/puffkit/container.py
@@ -25,7 +25,7 @@ class PkContainer(PkObject):
         self,
         app: PkApp,
         parent_surface: PkSurface,
-        name: str,
+        id_: str,
         rect: PkRect | RectValue,
         *,
         draw_outline: bool = False,
@@ -35,13 +35,13 @@ class PkContainer(PkObject):
         Args:
             app (PkApp): The app instance.
             parent_surface (PkSurface): The parent surface.
-            name (str): The name of the container.
+            id_ (str): The ID of the container.
             rect (PkRect | RectValue): The rectangle that the container occupies.
             draw_outline (bool): Whether to draw an outline around the container.
         """
         super().__init__()
         self.app: PkApp = app
-        self.name: str = name
+        self.id: str = id_
         self.draw_outline: bool = draw_outline
         self.parent_surface: PkSurface = parent_surface
 
@@ -96,7 +96,7 @@ class PkContainer(PkObject):
     def __str__(self) -> str:  # pragma: no cover
         """Return a human-friendly representation of the container."""
         return (
-            f"PkContainer({self.name} on {self.parent_surface},"
+            f"PkContainer({self.id} on {self.parent_surface},"
             f" {len(self.widgets)} widgets, {self.rect})"
         )
 
@@ -104,7 +104,7 @@ class PkContainer(PkObject):
         """Return a string representation of the container."""
         return (
             f"PkContainer({self.app}, {self.parent_surface},"
-            f" {self.name}, {self.rect})"
+            f" {self.id}, {self.rect})"
         )
 
     def add_widget(self, widget: PkWidget) -> None:


### PR DESCRIPTION
## PR type (check all applicable)

- [ ] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Fixes naming inconsistency in `PkContainer` where its id was called `name` 

## Related Tickets

- related issue #
- closes #63 

## Instructions, Screenshots

_replace this line with instructions (screenshots) on how to test, use your changes_
