### PR TITLE
fix(#61): unify hooks in widgets

### DIFF
--- a/src/puffkit/widget/button_widget.py
+++ b/src/puffkit/widget/button_widget.py
@@ -29,8 +29,8 @@ class PkButtonWidget(PkWidget):
         label: str,
         rect: PkRect | RectValue,
         *,
-        on_click: Callable[[PkButtonWidget, PkEvent], None] | None = None,
-        on_hover: Callable[[PkButtonWidget, PkEvent], None] | None = None,
+        click_hook: Callable[[PkButtonWidget, PkEvent], None] | None = None,
+        hover_hook: Callable[[PkButtonWidget, PkEvent], None] | None = None,
         disabled: bool = False,
         font_id: str = "default",
         background_color: PkColor | ColorValue = PkBasicPalette.GREY,
@@ -51,9 +51,9 @@ class PkButtonWidget(PkWidget):
             label (str): The label of the button.
             rect (PkRect | RectValue): The rectangle that the button occupies.
                 Relative to the container.
-            on_click (Any | None, optional): The action to perform when the
+            click_hook (Any | None, optional): The action to perform when the
                 button is clicked. Defaults to None.
-            on_hover (Any | None, optional): The action to perform when the
+            hover_hook (Any | None, optional): The action to perform when the
                 button is hovered. Defaults to None.
             disabled (bool, optional): Whether the button is disabled.
                 Defaults to False.
@@ -98,12 +98,12 @@ class PkButtonWidget(PkWidget):
 
         self.label: str = label
 
-        self.action_on_click: (
-            Callable[[PkButtonWidget, PkEvent], None] | None
-        ) = on_click
-        self.action_on_hover: (
-            Callable[[PkButtonWidget, PkEvent], None] | None
-        ) = on_hover
+        self.click_hook: Callable[[PkButtonWidget, PkEvent], None] | None = (
+            click_hook
+        )
+        self.hover_hook: Callable[[PkButtonWidget, PkEvent], None] | None = (
+            hover_hook
+        )
         self.disabled: bool = disabled
 
         self.font_id: str = font_id
@@ -143,14 +143,14 @@ class PkButtonWidget(PkWidget):
         return (
             f"PkButtonWidget(container={self.container} label={self.label}, "
             f"disabled={self.disabled}, "
-            f"on_click={self.action_on_click}, on_hover={self.action_on_hover})"
+            f"click_hook={self.click_hook}, hover_hook={self.hover_hook})"
         )
 
     def __repr__(self) -> str:  # pragma: no cover
         return (
             f"PkButtonWidget(container={self.container}, label={self.label}, "
             f"disabled={self.disabled}, "
-            f"on_click={self.action_on_click}, on_hover={self.action_on_hover})"
+            f"click_hook={self.click_hook}, hover_hook={self.hover_hook})"
         )
 
     def on_update(self, delta: float) -> None:
@@ -158,8 +158,8 @@ class PkButtonWidget(PkWidget):
 
     @override
     def on_click(self, event: PkEvent) -> None:
-        if callable(self.action_on_click):
-            self.action_on_click(self, event)
+        if callable(self.click_hook):
+            self.click_hook(self, event)
 
     @override
     def on_key_down(self, event: PkEvent) -> None:
@@ -172,13 +172,12 @@ class PkButtonWidget(PkWidget):
         if event.key in ["return", "space"]:
             self.pressed = False
 
+    @override
     def on_hover(self, event: PkEvent) -> None:
-        if self._disabled:
-            return
+        if callable(self.hover_hook):
+            self.hover_hook(self, event)
 
-        if callable(self.action_on_hover):
-            self.action_on_hover(self, event)
-
+    @override
     def on_render(self) -> None:
         # fill the surface with a background color depending on the state
         if self.disabled:

--- a/src/puffkit/widget/text_input_widget.py
+++ b/src/puffkit/widget/text_input_widget.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import pygame
 from puffkit import PkContainer
@@ -29,9 +29,11 @@ class PkTextInputWidget(PkWidget):
         rect: PkRect | RectValue,
         text: str = "",
         *,
-        on_change_hook: Any | None = None,
-        on_focus_hook: Any | None = None,
-        on_unfocus_hook: Any | None = None,
+        change_hook: Callable[[PkTextInputWidget, PkEvent], None]
+        | None = None,
+        focus_hook: Callable[[PkTextInputWidget, PkEvent], None] | None = None,
+        unfocus_hook: Callable[[PkTextInputWidget, PkEvent], None]
+        | None = None,
         disabled: bool = False,
         font_id: str = "default",
         background_color: PkColor | ColorValue = PkBasicPalette.GREY,
@@ -58,12 +60,12 @@ class PkTextInputWidget(PkWidget):
                 position and size.
             text (str, optional): The initial text in the text box.
                 Defaults to "".
-            on_change_hook (Any | None, optional): Callback function for text change
-                events. Defaults to None.
-            on_focus_hook (Any | None, optional): Callback function for focus events.
-                Defaults to None.
-            on_unfocus_hook (Any | None, optional): Callback function for unfocus
-                events. Defaults to None.
+            on_change_hook (Callable[[PkTextInputWidget, PkEvent], None] | None, optional):
+                Callback function for text change events. Defaults to None.
+            on_focus_hook (Callable[[PkTextInputWidget, PkEvent], None] | None, optional):
+                Callback function for focus events. Defaults to None.
+            on_unfocus_hook (Callable[[PkTextInputWidget, PkEvent], None] | None, optional):
+                Callback function for unfocus events. Defaults to None.
             disabled (bool, optional): Whether the widget is disabled.
                 Defaults to False.
             font_id (str, optional): The font ID for the text.
@@ -98,9 +100,15 @@ class PkTextInputWidget(PkWidget):
         super().__init__(id_, container, rect, focusable=True)
         self.text: str = text
 
-        self.on_change_hook: Any | None = on_change_hook
-        self.on_focus_hook: Any | None = on_focus_hook
-        self.on_unfocus_hook: Any | None = on_unfocus_hook
+        self.change_hook: (
+            Callable[[PkTextInputWidget, PkEvent], None] | None
+        ) = change_hook
+        self.focus_hook: (
+            Callable[[PkTextInputWidget, PkEvent], None] | None
+        ) = focus_hook
+        self.unfocus_hook: (
+            Callable[[PkTextInputWidget, PkEvent], None] | None
+        ) = unfocus_hook
 
         self.disabled: bool = disabled
         self.font_id: str = font_id
@@ -204,8 +212,8 @@ class PkTextInputWidget(PkWidget):
         if self.max_length == 0 or len(text) <= self.max_length:
             self.text = text
             self.cursor = len(self.text)
-            if self.on_change_hook and not suppress_hook:
-                self.on_change_hook(self)
+            if self.change_hook and not suppress_hook:
+                self.change_hook(self)
 
     def on_key_down(self, event: PkEvent) -> None:
         """Handle key down events.
@@ -244,8 +252,8 @@ class PkTextInputWidget(PkWidget):
                         + self.text[self.cursor :]
                     )
                     self.cursor += 1
-        if self.on_change_hook:
-            self.on_change_hook(self)
+        if self.change_hook:
+            self.change_hook(self, event)
 
     def on_focus(self, event: PkEvent) -> None:
         """Handle focus events.
@@ -259,8 +267,8 @@ class PkTextInputWidget(PkWidget):
         pygame.key.set_repeat(500, 50)
 
         self.cursor_blink_timer = 0
-        if self.on_focus_hook:
-            self.on_focus_hook(self)
+        if self.focus_hook:
+            self.focus_hook(self, event)
 
     def on_unfocus(self, event: PkEvent) -> None:
         """Handle unfocus events.
@@ -273,8 +281,8 @@ class PkTextInputWidget(PkWidget):
 
         pygame.key.set_repeat()
 
-        if self.on_unfocus_hook:
-            self.on_unfocus_hook(self)
+        if self.unfocus_hook:
+            self.unfocus_hook(self, event)
 
     def on_update(self, delta: float) -> None:
         """Update the text input widget.

--- a/tests/widget/test_button_widget.py
+++ b/tests/widget/test_button_widget.py
@@ -44,8 +44,8 @@ def button_widget(mock_container: Mock):
         container=mock_container,
         rect=PkRect(0, 0, 100, 50),
         label="Click Me",
-        on_click=MagicMock(),
-        on_hover=MagicMock(),
+        click_hook=MagicMock(),
+        hover_hook=MagicMock(),
         disabled=False,
         font_id="default",
         background_color=PkBasicPalette.GREY,
@@ -59,7 +59,7 @@ def button_widget(mock_container: Mock):
 
 
 @pytest.mark.parametrize(
-    "rect, label, on_click, on_hover, disabled, font_id, background_color, "
+    "rect, label, click_hook, hover_hook, disabled, font_id, background_color, "
     "background_color_disabled, background_color_pressed, "
     "background_color_hovered, text_color, text_align, border_radius",
     [
@@ -114,8 +114,8 @@ def test_button_initialization(
     mock_container: Mock,
     rect: PkRect,
     label: str,
-    on_click: Mock,
-    on_hover: Mock,
+    click_hook: Mock,
+    hover_hook: Mock,
     disabled: bool,
     font_id: str,
     background_color: PkColor,
@@ -132,8 +132,8 @@ def test_button_initialization(
         container=mock_container,
         rect=rect,
         label=label,
-        on_click=on_click,
-        on_hover=on_hover,
+        click_hook=click_hook,
+        hover_hook=hover_hook,
         disabled=disabled,
         font_id=font_id,
         background_color=background_color,
@@ -146,17 +146,17 @@ def test_button_initialization(
     )
 
 
-def test_button_on_click_action(button_widget: PkButtonWidget):
-    """Test the on_click action of the button."""
+def test_button_click_hook_action(button_widget: PkButtonWidget):
+    """Test the click_hook action of the button."""
     button_widget._pressed = True
-    button_widget.on_click(Mock(spec=PkEvent))
-    button_widget.action_on_click.assert_called_once()
+    button_widget.click_hook(Mock(spec=PkEvent))
+    button_widget.click_hook.assert_called_once()
 
 
-def test_button_on_hover_action(button_widget: PkButtonWidget):
-    """Test the on_hover action of the button."""
-    button_widget.on_hover(Mock(spec=PkEvent))
-    button_widget.action_on_hover.assert_called_once()
+def test_button_hover_hook_action(button_widget: PkButtonWidget):
+    """Test the hover_hook action of the button."""
+    button_widget.hover_hook(Mock(spec=PkEvent))
+    button_widget.hover_hook.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -240,10 +240,7 @@ def test_button_on_hover(button_widget: PkButtonWidget, disabled: bool, event: M
     """Test the on_hover method of the button widget."""
     button_widget._disabled = disabled
     button_widget.on_hover(event)
-    if disabled:
-        button_widget.action_on_hover.assert_not_called()
-    else:
-        button_widget.action_on_hover.assert_called_once()
+    button_widget.hover_hook.assert_called_once()
 
 @pytest.mark.parametrize(
     "disabled, event",
@@ -262,10 +259,10 @@ def test_button_on_key_down(button_widget: PkButtonWidget, disabled: bool, event
     button_widget.on_key_down(event)
 
     if event.key in ["return", "space"]:
-        button_widget.action_on_click.assert_called_with(button_widget, event)
+        button_widget.click_hook.assert_called_with(button_widget, event)
         assert button_widget.disabled is disabled
     else:
-        button_widget.action_on_click.assert_not_called()
+        button_widget.click_hook.assert_not_called()
 
 @pytest.mark.parametrize(
     "event",

--- a/tests/widget/test_text_input_widget.py
+++ b/tests/widget/test_text_input_widget.py
@@ -34,9 +34,9 @@ def text_input_widget(mock_container):
         text="",
         max_length=10,
         placeholder="Enter text",
-        on_change_hook=Mock(),
-        on_focus_hook=Mock(),
-        on_unfocus_hook=Mock(),
+        change_hook=Mock(),
+        focus_hook=Mock(),
+        unfocus_hook=Mock(),
     )
 
 
@@ -73,14 +73,15 @@ def test_on_key_down_no_focus(text_input_widget):
 
 def test_on_key_down_action(text_input_widget):
     """Test the on_key_down method with an action key."""
+    event = Mock(key="enter", unicode="")
     text_input_widget.focused = True
-    text_input_widget.on_change_hook = Mock()
+    text_input_widget.change_hook = Mock()
     initial_text = "hello"
     text_input_widget.text = initial_text
     text_input_widget.cursor = len(initial_text)
-    text_input_widget.on_key_down(Mock(key="enter", unicode=""))
+    text_input_widget.on_key_down(event)
     assert text_input_widget.text == initial_text
-    text_input_widget.on_change_hook.assert_called_once_with(text_input_widget)
+    text_input_widget.change_hook.assert_called_once_with(text_input_widget, event)
 
 
 def test_on_focus(text_input_widget):
@@ -88,18 +89,18 @@ def test_on_focus(text_input_widget):
     mock_event = Mock()
 
     # widget not disabled
-    text_input_widget.on_focus_hook = Mock()
+    text_input_widget.focus_hook = Mock()
     text_input_widget.on_focus(mock_event)
     assert text_input_widget.cursor_blink_timer == 0
-    assert text_input_widget.on_focus_hook.called
+    assert text_input_widget.focus_hook.called
 
     # widget disabled
     text_input_widget.disabled = True
     text_input_widget.cursor_blink_timer = 0.5
-    text_input_widget.on_focus_hook = Mock()
+    text_input_widget.focus_hook = Mock()
     text_input_widget.on_focus(mock_event)
     assert text_input_widget.cursor_blink_timer == 0.5  # ensure the timer is not reset
-    text_input_widget.on_focus_hook.assert_not_called()
+    text_input_widget.focus_hook.assert_not_called()
 
 
 def test_on_unfocus(text_input_widget):
@@ -107,9 +108,9 @@ def test_on_unfocus(text_input_widget):
     mock_event = Mock()
 
     # widget not disabled
-    text_input_widget.on_unfocus_hook = Mock()
+    text_input_widget.unfocus_hook = Mock()
     text_input_widget.on_unfocus(mock_event)
-    text_input_widget.on_unfocus_hook.assert_called_once_with(text_input_widget)
+    text_input_widget.unfocus_hook.assert_called_once_with(text_input_widget, mock_event)
 
     # widget disabled
     text_input_widget.disabled = True
@@ -176,7 +177,7 @@ def test_set_text_no_suppress(text_input_widget):
     text_input_widget.set_text(new_text, suppress_hook=False)
     assert text_input_widget.text == new_text
     assert text_input_widget.cursor == len(new_text)  # cursor should be at the end
-    text_input_widget.on_change_hook.assert_called_once_with(text_input_widget)
+    text_input_widget.change_hook.assert_called_once_with(text_input_widget)
 
 
 def test_set_text_with_suppress(text_input_widget):
@@ -186,4 +187,4 @@ def test_set_text_with_suppress(text_input_widget):
     text_input_widget.set_text(new_text, suppress_hook=True)
     assert text_input_widget.text == new_text
     assert text_input_widget.cursor == len(new_text)  # cursor should be at the end
-    text_input_widget.on_change_hook.assert_not_called()  # hook should not be called
+    text_input_widget.change_hook.assert_not_called()  # hook should not be called


### PR DESCRIPTION
## PR type (check all applicable)

- [ ] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [x] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Unifies widget hook naming schemes

## Related Tickets

- related issue #
- closes #61 

## Instructions, Screenshots

_replace this line with instructions (screenshots) on how to test, use your changes_
